### PR TITLE
npm postinstall script to install dialog files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/dialogs/dialog-id.json

--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ var dialog_id_in_json = (function() {
   try {
     var dialogsFile = path.join(path.dirname(__filename), 'dialogs', 'dialog-id.json');
     var obj = JSON.parse(fs.readFileSync(dialogsFile));
-    return Object.keys(obj)[0];
+    return obj[Object.keys(obj)[0]].id;
   } catch (e) {
   }
 })();

--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@
 
 var express  = require('express'),
   app        = express(),
+  fs         = require('fs'),
   path       = require('path'),
   bluemix    = require('./config/bluemix'),
   extend     = require('util')._extend,
@@ -34,7 +35,18 @@ var credentials =  extend({
   version: 'v1'
 }, bluemix.getServiceCreds('dialog')); // VCAP_SERVICES
 
-var dialog_id = process.env.DIALOG_ID || '<dialog-id>';
+
+var dialog_id_in_json = (function() {
+  try {
+    var dialogsFile = path.join(path.dirname(__filename), 'dialogs', 'dialog-id.json');
+    var obj = JSON.parse(fs.readFileSync(dialogsFile));
+    return Object.keys(obj)[0];
+  } catch (e) {
+  }
+})();
+
+
+var dialog_id = process.env.DIALOG_ID || dialog_id_in_json || '<missing-dialog-id>';
 
 // Create the service wrapper
 var dialog = watson.dialog(credentials);

--- a/dialogs/install-dialogs.js
+++ b/dialogs/install-dialogs.js
@@ -68,21 +68,21 @@ var dialogService = {
                 },
                 formData: formData
             },
-            function(error, reponse, body) {
+            function(error, response, body) {
 
                 if (error) {
                     cb(error);
                 } else {
-                    if (reponse.statusCode < 300) {
-                        if (reponse.statusCode === 201) {
+                    if (response.statusCode < 300) {
+                        if (response.statusCode === 201) {
                             var info = JSON.parse(body);
-                            id = info.id;
+                            id = info.dialog_id;
                         }
                         var pair = {};
                         pair[name] = id;
                         cb(null, pair);
                     } else {
-                        cb(new Error(':-( HTTP status: ' + reponse.statusCode));
+                        cb(new Error(':-( HTTP status: ' + response.statusCode));
                     }
                 }
             });
@@ -134,7 +134,7 @@ function updateDialogFiles(credentials) {
             var dialogsFile = path.join(path.dirname(__filename), 'dialog-id.json');
             fs.writeFileSync(dialogsFile, 
                              JSON.stringify(dialogFiles.get(), null, 4));
-            console.log(':-)');
+            console.log('dialog files processed');
         }
     }
 

--- a/dialogs/install-dialogs.js
+++ b/dialogs/install-dialogs.js
@@ -1,0 +1,175 @@
+//
+// POST/PUT to https://gateway.watsonplatform.net/dialog/api
+// all the *.xml files in this directory.
+//
+// The files are uploaded with a name based on the file name plus the first
+// characters of the username defined in the dialosg service credentials.
+//
+// A file called 'dialog-id.json' is kept with the ids returned by the service
+// for each of the files.
+//
+
+
+'use strict';
+
+var async = require('async'),
+    bluemix = require('../config/bluemix'),
+    fs = require('fs'),
+    path = require('path'),
+    request = require('request');
+
+var dialogService = {
+    getDialogs: function(credentials, cb) {
+        request({
+            url: credentials.url + '/v1/dialogs',
+            auth: {
+                user: credentials.username,
+                pass:credentials.password
+            }
+        },
+        function(error, response, body) {
+            if (error) {
+                cb(error);
+            } else {
+                var dialogs = {};
+                JSON.parse(body).dialogs.forEach(function (el) {
+                    dialogs[el.name] = el.dialog_id;
+                });
+                cb(null, dialogs);
+            }
+        });
+    },
+    setDialog: function(credentials, name, id, fullPath, cb) {
+        var url,
+            method,
+            fileName = name + '.xml',
+            formData = {
+                file: {
+                    value: fs.createReadStream(fullPath),
+                    options: {
+                        filename: fileName
+                    }
+                }
+            };
+        if (id === 'pending') {
+            url = credentials.url + '/v1/dialogs';
+            method = 'POST';
+            formData.name = name;
+        } else {
+            url = credentials.url + '/v1/dialogs/' + id;
+            method = 'PUT';
+        }
+        request({
+                method: method,
+                url: url,
+                auth: {
+                    user: credentials.username,
+                    pass:credentials.password
+                },
+                formData: formData
+            },
+            function(error, reponse, body) {
+
+                if (error) {
+                    cb(error);
+                } else {
+                    if (reponse.statusCode < 300) {
+                        if (reponse.statusCode === 201) {
+                            var info = JSON.parse(body);
+                            id = info.id;
+                        }
+                        var pair = {};
+                        pair[name] = id;
+                        cb(null, pair);
+                    } else {
+                        cb(new Error(':-( HTTP status: ' + reponse.statusCode));
+                    }
+                }
+            });
+    }
+};
+
+var dialogFiles = (function() {
+    var fileInfo = {};
+    var thisDir = path.dirname(__filename);
+
+    function getXmlFilesInThisDir() {
+        var xmlFiles = fs.readdirSync(thisDir).filter(function(aFile) {
+            var fp = path.join(thisDir, aFile);
+            return !fs.statSync(fp).isDirectory() &&
+                   path.extname(fp).match(/^\.xml$/i);
+        });
+        return xmlFiles.map(function(aFile) {return aFile.replace(/\.xml$/i, '');});
+    }
+
+    return {
+        loadFromDisk: function(userName) {
+            var suffix = '_' + userName.substring(0, 8);
+            fileInfo = {};
+            getXmlFilesInThisDir().forEach(function(name) {
+                var key = name + suffix;
+                var fp = path.join(thisDir, name + '.xml');
+                fileInfo[key] = {id: 'pending', fullPath: fp};
+            });
+        },
+        updateWithServiceInfo: function(serviceInfo) {
+            for (var key in fileInfo) {
+                if (fileInfo.hasOwnProperty(key)) {
+                    if (serviceInfo[key]) {
+                        fileInfo[key].id = serviceInfo[key];
+                    }
+                }
+            }
+        },
+        get: function() {return fileInfo;}
+    };
+})();
+
+
+function updateDialogFiles(credentials) {
+    function allDialogsProcessedCb(error) {
+        if (error) {
+            console.error('done :-(');
+        } else {
+            var dialogsFile = path.join(path.dirname(__filename), 'dialog-id.json');
+            fs.writeFileSync(dialogsFile, 
+                             JSON.stringify(dialogFiles.get(), null, 4));
+            console.log(':-)');
+        }
+    }
+
+    function getDialogsCb(error, installed) {
+        if (error) {
+            console.error('something went wrong fetching dialogs: ' + error);
+        } else {
+            dialogFiles.loadFromDisk(credentials.username);
+            dialogFiles.updateWithServiceInfo(installed);
+
+            var processDialog = function(value, name, cb) {
+                var dialogProcessedCb = function(error, pair) {
+                    if (error) {
+                        console.error('something went wrong with dialog "' + name + '": ' + error);
+                        cb(error);
+                    } else {
+                        dialogFiles.get()[name].id = pair[name];
+                        cb();
+                    }
+                };
+                dialogService.setDialog(credentials, name, value.id, value.fullPath, 
+                                        dialogProcessedCb);
+            };
+            async.forEachOf(dialogFiles.get(),
+                            processDialog,
+                            allDialogsProcessedCb);
+        }
+    }
+
+    if (credentials && credentials.username) {
+        dialogService.getDialogs(credentials, getDialogsCb);
+    } else {
+        console.warn('WARNING: Missing credentials or VCAP_SERVICES. Not installing dialog files.');
+    }
+}
+
+
+updateDialogFiles(bluemix.getServiceCreds('dialog'));

--- a/package.json
+++ b/package.json
@@ -29,12 +29,15 @@
     "url": "https://github.com/watson-developer-cloud/dialog-nodejs/issues"
   },
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "postinstall": "node dialogs/install-dialogs.js"
   },
   "dependencies": {
+    "async": "^1.5.1",
     "body-parser": "~1.14.1",
     "errorhandler": "~1.4.1",
     "express": "~4.13.3",
+    "request": "^2.67.0",
     "watson-developer-cloud": "~1.0.6"
   }
 }


### PR DESCRIPTION
In order to have the 'deploy to bluemix' working out of the box, an `install-dialogs.js` script adds to the service all the XML files it finds in the `dialogs` dir. This is set as the npm postinstall script, so that after a cf push is done, 
* `pizza_sample.xml` is added to the service with the `dialog` service credentials
* the file `dialogs/dialog-id.json` holds the id of the installed dialog
* `app.js` gets the dialog id from the above file